### PR TITLE
Modified some things to make use more consistent with traditional editors

### DIFF
--- a/richedit/src/main/java/com/commonsware/cwac/richedit/LineAlignmentEffect.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richedit/LineAlignmentEffect.java
@@ -50,7 +50,7 @@ public class LineAlignmentEffect extends Effect<Layout.Alignment> {
 
     if (alignment!=null) {
       str.setSpan(new AlignmentSpan.Standard(alignment), selection.getStart(), selection.getEnd(),
-                  Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+                  Spannable.SPAN_PARAGRAPH);
     }
   }
 
@@ -66,7 +66,7 @@ public class LineAlignmentEffect extends Effect<Layout.Alignment> {
       for (Selection chunk : selection.buildSelectionsForLines(str)) {
         str.setSpan(new AlignmentSpan.Standard(alignment), chunk.getStart(),
                     chunk.getEnd(),
-                    Spannable.SPAN_INCLUSIVE_INCLUSIVE);
+                    Spannable.SPAN_PARAGRAPH);
       }
     }
   }

--- a/richedit/src/main/java/com/commonsware/cwac/richedit/SimpleBooleanEffect.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richedit/SimpleBooleanEffect.java
@@ -39,10 +39,8 @@ public class SimpleBooleanEffect<T> extends Effect<Boolean> {
     else {
       T[] spansBefore=
           str.getSpans(selection.getStart() - 1, selection.getEnd(), clazz);
-      T[] spansAfter=
-          str.getSpans(selection.getStart(), selection.getEnd() + 1, clazz);
 
-      result=(spansBefore.length > 0 && spansAfter.length > 0);
+      result=(spansBefore.length > 0);
     }
 
     return(result);
@@ -82,18 +80,18 @@ public class SimpleBooleanEffect<T> extends Effect<Boolean> {
     try {
       if (add) {
         str.setSpan(clazz.newInstance(), selection.getStart(),
-                    selection.getEnd(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    selection.getEnd(), Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
       }
       else {
         if (prologueStart < Integer.MAX_VALUE) {
           str.setSpan(clazz.newInstance(), prologueStart,
                       selection.getStart(),
-                      Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                      Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
         }
 
         if (epilogueEnd > -1) {
           str.setSpan(clazz.newInstance(), selection.getEnd(),
-                      epilogueEnd, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                      epilogueEnd, Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
         }
       }
     }

--- a/richedit/src/main/java/com/commonsware/cwac/richedit/StyleEffect.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richedit/StyleEffect.java
@@ -43,25 +43,11 @@ public class StyleEffect extends Effect<Boolean> {
       StyleSpan[] spansBefore=
           str.getSpans(selection.getStart() - 1, selection.getEnd(),
                        StyleSpan.class);
-      StyleSpan[] spansAfter=
-          str.getSpans(selection.getStart(), selection.getEnd() + 1,
-                       StyleSpan.class);
 
       for (StyleSpan span : spansBefore) {
         if (span.getStyle() == style) {
           result=true;
           break;
-        }
-      }
-
-      if (result) {
-        result=false;
-
-        for (StyleSpan span : spansAfter) {
-          if (span.getStyle() == style) {
-            result=true;
-            break;
-          }
         }
       }
     }
@@ -103,17 +89,17 @@ public class StyleEffect extends Effect<Boolean> {
 
     if (add) {
       str.setSpan(new StyleSpan(style), selection.getStart(), selection.getEnd(),
-                  Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                  Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
     }
     else {
       if (prologueStart < Integer.MAX_VALUE) {
         str.setSpan(new StyleSpan(style), prologueStart,
-                    selection.getStart(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    selection.getStart(), Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
       }
 
       if (epilogueEnd > -1) {
         str.setSpan(new StyleSpan(style), selection.getEnd(), epilogueEnd,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    Spannable.SPAN_EXCLUSIVE_INCLUSIVE);
       }
     }
   }


### PR DESCRIPTION
Hi, I used your library for a docx editor app I was working on. Thanks for the sweet library!

I made a few changes which I think would improve your editor while I was using it, and I wanted to see if you would like to add them to your own editor as well.

I changed the boolean effects and style effects flags from SPAN_EXCLUSIVE_EXCLUSIVE to SPAN_EXCLUSIVE_INCLUSIVE instead, making it more similar to regular editors:

![](http://i.imgur.com/4sSBK7T.png)![](http://i.imgur.com/OfwGoBA.png)

![](http://i.imgur.com/Ttxjleb.png)

The main change is that appended text keeps the style.

I also changed the flags for Alignment from SPAN_INCLUSIVE_INCLUSIVE to SPAN_PARAGRAPH. This makes it work a bit bitter / more logical in the way it works:

![](http://i.imgur.com/zgN6e7v.png)
![](http://i.imgur.com/OSlXzgb.png)

To get those results, I typed:

This is the

old *right aligned old*

way *hit left align on this line*

In the old way, the last left align would affect both this line and the preceding line. In the new way, the right align still sticks when going to new lines, but hitting left align affects only the line it was pressed on.