### PR TITLE
Pull request with some bugfixes

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -15,4 +15,6 @@ dependencies {
     debugCompile project(':richedit')
     releaseCompile 'com.commonsware.cwac:richedit:0.5.+'
     compile 'com.commonsware.cwac:colormixer:0.6.+'
+    compile 'com.android.support:support-v4:22.0.0'
+    compile 'com.android.support:appcompat-v7:22.0.0'
 }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
 
 		<activity
 			android:name=".RichTextEditorDemoActivity"
+			android:windowSoftInputMode="adjustResize"
 			android:label="@string/app_name">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>

--- a/demo/src/main/java/com/commonsware/cwac/richedit/demo/RichTextEditorDemoActivity.java
+++ b/demo/src/main/java/com/commonsware/cwac/richedit/demo/RichTextEditorDemoActivity.java
@@ -15,30 +15,50 @@
 package com.commonsware.cwac.richedit.demo;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
 import android.text.Selection;
+import android.text.style.URLSpan;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
 import com.commonsware.cwac.colormixer.ColorMixerActivity;
 import com.commonsware.cwac.richedit.ColorPicker;
 import com.commonsware.cwac.richedit.ColorPickerOperation;
 import com.commonsware.cwac.richedit.RichEditText;
-import com.commonsware.cwac.richedit.URLEffect;
+import com.commonsware.cwac.richtextutils.SpannableStringGenerator;
+import com.commonsware.cwac.richtextutils.SpannedXhtmlGenerator;
 
-public class RichTextEditorDemoActivity extends Activity
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+public class RichTextEditorDemoActivity extends ActionBarActivity
   implements ColorPicker {
   private static final int COLOR_REQUEST=1337;
   private RichEditText editor=null;
   private ColorPickerOperation colorPickerOp=null;
-  
+
+  TextView viewer;
+
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    
     setContentView(R.layout.main);
-    
+    setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
+
     editor=(RichEditText)findViewById(R.id.editor);
+    viewer= (TextView) findViewById(R.id.viewer);
     editor.setColorPicker(this);
     editor.enableActionModes(true);
   }
@@ -57,7 +77,7 @@ public class RichTextEditorDemoActivity extends Activity
         int offset=editor.getText().length();
         editor.append(" CommonsWare rocks!");
         editor.setSelection(offset+1, editor.getText().length());
-        editor.applyEffect(new URLEffect(), "https://commonsware.com");
+        editor.applyEffect(RichEditText.URL, "https://commonsware.com");
 
         Selection.removeSelection(editor.getText());
 
@@ -101,6 +121,71 @@ public class RichTextEditorDemoActivity extends Activity
       }
 
       colorPickerOp=null;
+    }
+  }
+
+  public void RichTextAction(View v) {
+    switch (v.getId()) {
+      case R.id.viewxml:
+        if (editor.getVisibility() == View.VISIBLE) {
+          editor.setVisibility(View.GONE);
+          viewer.setVisibility(View.VISIBLE);
+          viewer.setText(new SpannedXhtmlGenerator().toXhtml(editor.getText()));
+          ((Button)v).setText("edit");
+        } else {
+          editor.setVisibility(View.VISIBLE);
+          viewer.setVisibility(View.GONE);
+          try {
+            editor.setText(new SpannableStringGenerator().fromXhtml(viewer.getText().toString()));
+          } catch (ParserConfigurationException | SAXException | IOException e) {
+            editor.setVisibility(View.GONE);
+            viewer.setVisibility(View.VISIBLE);
+            viewer.setText(e.getMessage());
+          }
+          ((Button)v).setText("xml");
+        }
+        break;
+      case R.id.bullet:
+        editor.toggleEffect(RichEditText.BULLET);
+        break;
+      case R.id.link:
+        final int selStart;
+        final int selEnd;
+        URLSpan[] links = editor.getText().getSpans(editor.getSelectionStart(), editor.getSelectionEnd(), URLSpan.class);
+        final EditText editText = new EditText(this);
+        if (links.length > 0) {
+          selStart = Math.min(editor.getText().getSpanStart(links[0]), editor.getSelectionStart());
+          selEnd = Math.max(editor.getText().getSpanEnd(links[links.length - 1]), editor.getSelectionEnd());
+          editText.setText(links[0].getURL());
+        } else {
+          selStart = editor.getSelectionStart();
+          selEnd = editor.getSelectionEnd();
+        }
+        new AlertDialog.Builder(this)
+                .setTitle("Link URL")
+                .setView(editText)
+                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
+                  @Override
+                  public void onClick(DialogInterface dialog, int which) {
+                    String url = editText.getText().toString();
+                    if (selStart == selEnd) {
+                      editor.getText().insert(selStart, url);
+                      editor.setSelection(selStart, selEnd + url.length());
+                    } else {
+                      editor.setSelection(selStart, selEnd);
+                    }
+                    editor.applyEffect(RichEditText.URL, url);
+                    editor.setSelection(editor.getSelectionEnd());
+                  }
+                })
+                .setNegativeButton("CANCEL", new DialogInterface.OnClickListener() {
+                  @Override
+                  public void onClick(DialogInterface dialog, int which) {
+                    dialog.dismiss();
+                  }
+                })
+                .show();
+        break;
     }
   }
 }

--- a/demo/src/main/res/layout/main.xml
+++ b/demo/src/main/res/layout/main.xml
@@ -1,7 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.commonsware.cwac.richedit.RichEditText xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/editor"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:gravity="left|top"
-	android:imeOptions="flagNoExtractUi"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical">
+
+	<android.support.v7.widget.Toolbar
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto"
+		android:id="@+id/toolbar"
+		android:layout_height="wrap_content"
+		android:layout_width="match_parent"
+		android:minHeight="?attr/actionBarSize"
+		android:background="?attr/colorPrimary" />
+	<com.commonsware.cwac.richedit.RichEditText
+		android:id="@+id/editor"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1"
+		android:gravity="top"
+		android:padding="8dp"
+		android:background="@android:color/transparent"
+		android:imeOptions="flagNoExtractUi"/>
+
+	<EditText
+		android:id="@+id/viewer"
+		android:layout_width="match_parent"
+		android:layout_height="0dp"
+		android:layout_weight="1"
+		android:gravity="top"
+		android:padding="8dp"
+		android:background="@android:color/transparent"
+		android:imeOptions="flagNoExtractUi"
+		android:visibility="gone"/>
+
+	<LinearLayout
+		android:layout_width="match_parent"
+		android:layout_height="wrap_content">
+		<Button style="@style/RichTextAction"
+			android:id="@+id/viewxml" android:text="xml"/>
+		<!--<Button style="@style/RichTextAction"-->
+			<!--android:id="@+id/bold" android:text="bold"/>-->
+		<!--<Button style="@style/RichTextAction"-->
+			<!--android:id="@+id/italic" android:text="italic"/>-->
+		<!--<Button style="@style/RichTextAction"-->
+			<!--android:id="@+id/underline" android:text="underline"/>-->
+		<!--<Button style="@style/RichTextAction"-->
+			<!--android:id="@+id/del" android:text="del"/>-->
+		<Button style="@style/RichTextAction"
+			android:id="@+id/bullet" android:text="bullet"/>
+		<Button style="@style/RichTextAction"
+			android:id="@+id/link" android:text="link"/>
+	</LinearLayout>
+
+</LinearLayout>

--- a/demo/src/main/res/values-v21/styles.xml
+++ b/demo/src/main/res/values-v21/styles.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <style name="Theme.Apptheme" parent="android:Theme.Material.Light.DarkActionBar">
-    <item name="android:colorPrimary">@color/primary</item>
-    <item name="android:colorPrimaryDark">@color/primary_dark</item>
-    <item name="android:colorAccent">@color/accent</item>
-    <item name="android:actionModeBackground">@color/primary</item>
-  </style>
-</resources>

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <style name="Theme.Apptheme" parent="@android:style/Theme.Holo.Light.DarkActionBar">
+  <style name="Theme.Apptheme" parent="@style/Theme.AppCompat.Light">
+    <item name="windowActionBar">false</item>
+  </style>
+
+  <style name="RichTextAction">
+    <item name="android:layout_width">56dp</item>
+    <item name="android:layout_height">48dp</item>
+    <item name="android:onClick">RichTextAction</item>
+    <item name="android:background">@android:color/transparent</item>
   </style>
 </resources>

--- a/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
+++ b/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
@@ -42,6 +42,14 @@ public class ManualXhtmlTests extends TestCase {
     }
   }
 
+    public void testBr() throws Exception {
+        final String input="a<br/>b";
+        SpanTagRoster tagRoster=new SpanTagRoster();
+        Spanned fromInput=new SpannableStringGenerator(tagRoster).fromXhtml(input);
+        String roundTrip=new SpannedXhtmlGenerator(tagRoster).toXhtml(fromInput);
+        assertEquals(input, roundTrip);
+    }
+
   public void testClassSpanTagHandler() throws IOException, SAXException, ParserConfigurationException {
     SpanTagRoster tagRoster=new SpanTagRoster();
 

--- a/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
+++ b/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
@@ -43,7 +43,7 @@ public class ManualXhtmlTests extends TestCase {
   }
 
     public void testBr() throws Exception {
-        final String input="a<br/>b";
+        final String input="a<br/>b<br/>c";
         SpanTagRoster tagRoster=new SpanTagRoster();
         Spanned fromInput=new SpannableStringGenerator(tagRoster).fromXhtml(input);
         String roundTrip=new SpannedXhtmlGenerator(tagRoster).toXhtml(fromInput);

--- a/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
+++ b/richedit/src/androidTest/java/com/commonsware/cwac/richtextutils/test/ManualXhtmlTests.java
@@ -50,6 +50,14 @@ public class ManualXhtmlTests extends TestCase {
         assertEquals(input, roundTrip);
     }
 
+    public void testDiv() throws Exception {
+        final String input="<div>a</div><div></div><br/>";
+        SpanTagRoster tagRoster=new SpanTagRoster();
+        Spanned fromInput=new SpannableStringGenerator(tagRoster).fromXhtml(input);
+        String roundTrip=new SpannedXhtmlGenerator(tagRoster).toXhtml(fromInput);
+        assertEquals(input, roundTrip);
+    }
+
   public void testClassSpanTagHandler() throws IOException, SAXException, ParserConfigurationException {
     SpanTagRoster tagRoster=new SpanTagRoster();
 

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/Selection.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/Selection.java
@@ -63,9 +63,12 @@ public class Selection {
       }
     }
 
-    for (newEnd=end;newEnd<src.length()-1;newEnd++) {
-      if (src.charAt(newEnd+1)=='\n') {
-        break;
+    newEnd = end;
+    if (newEnd < src.length() && src.charAt(newEnd) != '\n') {
+      for (; newEnd < src.length() - 1; newEnd++) {
+        if (src.charAt(newEnd + 1) == '\n') {
+          break;
+        }
       }
     }
 

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
@@ -99,6 +99,14 @@ public class SpannedXhtmlGenerator {
   private void chunkToXhtml(SpannableStringBuilder result, final Spanned src,
                               Layout.Alignment align) {
     BulletSpan[] spans=src.getSpans(0, src.length(), BulletSpan.class);
+    Arrays.sort(spans, new Comparator<BulletSpan>() {
+      @Override
+      public int compare(BulletSpan lhs, BulletSpan rhs) {
+        int a = src.getSpanStart(lhs);
+        int b = src.getSpanStart(rhs);
+        return a < b ? -1 : a == b ? 0 : 1;
+      }
+    });
 
     if (spans.length==0) {
       result.append(blockToXhtml(src, align));

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
@@ -96,7 +96,7 @@ public class SpannedXhtmlGenerator {
     return(result.toString());
   }
 
-  private void chunkToXhtml(SpannableStringBuilder result, Spanned src,
+  private void chunkToXhtml(SpannableStringBuilder result, final Spanned src,
                               Layout.Alignment align) {
     BulletSpan[] spans=src.getSpans(0, src.length(), BulletSpan.class);
 
@@ -109,12 +109,10 @@ public class SpannedXhtmlGenerator {
 
       for (BulletSpan span : spans) {
         int spanStart=src.getSpanStart(span);
-        int spanEnd=src.getSpanEnd(span);
 
         if (spanStart > lastSpanEnd) {
           if (inBulletRun) {
             result.append("</ul>");
-            inBulletRun=false;
           }
 
           if (spanStart > 0) {
@@ -136,13 +134,16 @@ public class SpannedXhtmlGenerator {
 
         result.append("<li>");
 
-        Spanned sub=(Spanned)src.subSequence(spanStart, spanEnd - 1);
-                                    // -1 to remove trailing newline
+        int spanEnd=spanStart;
+        while (spanEnd < src.length() && src.charAt(spanEnd) != '\n')
+          spanEnd++;
+
+        Spanned sub=(Spanned)src.subSequence(spanStart, spanEnd);
 
         result.append(blockToXhtml(sub, null));
         result.append("</li>");
 
-        lastSpanEnd=spanEnd;
+        lastSpanEnd=spanEnd + 1;
       }
 
       if (inBulletRun) {

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
@@ -116,14 +116,8 @@ public class SpannedXhtmlGenerator {
           }
 
           if (spanStart > 0) {
-            int subsequenceStart=(lastSpanEnd < 0 ? 0 : lastSpanEnd);
-            int subsequenceEnd=spanStart;
-
-            if (src.charAt(spanStart)=='\n' && !inBulletRun) {
-              subsequenceEnd--; // to remove leading newline
-            }
-
-            result.append(src.subSequence(subsequenceStart, subsequenceEnd));
+            Spanned spanned = (Spanned) src.subSequence(lastSpanEnd < 0 ? 0 : lastSpanEnd, spanStart);
+            result.append(blockToXhtml(spanned, null));
           }
 
           result.append("<ul");

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/SpannedXhtmlGenerator.java
@@ -266,11 +266,18 @@ public class SpannedXhtmlGenerator {
 
     result=new StringBuilder();
 
-    if (baseResult.endsWith("</div><div>")) {
+    if (baseResult.endsWith("</div><div><br/>")) {
       result.append("<div");
       result.append(buildAlignStyle(align));
       result.append('>');
-      result.append(baseResult.substring(0, baseResult.length()-5));
+      result.append(baseResult, 0, baseResult.length() - 10);
+      result.append("<br/>");
+    }
+    else if (baseResult.endsWith("</div><div>")) {
+      result.append("<div");
+      result.append(buildAlignStyle(align));
+      result.append('>');
+      result.append(baseResult, 0, baseResult.length() - 5);
     }
     else if (baseResult.contains("</div><div>") || align!=null) {
       result.append("<div");

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/XhtmlSaxHandler.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/XhtmlSaxHandler.java
@@ -83,6 +83,7 @@ class XhtmlSaxHandler extends DefaultHandler {
       textStack.peek().append("\n\n");
     }
     else if ("br".equals(name)) {
+      textStack.pop();
       textStack.peek().append("\n");
     }
     else if ("ul".equals(name)) {

--- a/richedit/src/main/java/com/commonsware/cwac/richtextutils/XhtmlSaxHandler.java
+++ b/richedit/src/main/java/com/commonsware/cwac/richtextutils/XhtmlSaxHandler.java
@@ -71,7 +71,7 @@ class XhtmlSaxHandler extends DefaultHandler {
     else if ("div".equals(name) && style!=null) {
       handleAlignment(style);
     }
-    else if (Arrays.binarySearch(NO_ITEM_TAGS, name)<=0) {
+    else if (Arrays.binarySearch(NO_ITEM_TAGS, name)<0) {
       Object span=tagRoster.buildSpanForTag(name, a);
 
       textStack.push(new Item(span, ""));
@@ -83,7 +83,6 @@ class XhtmlSaxHandler extends DefaultHandler {
       textStack.peek().append("\n\n");
     }
     else if ("br".equals(name)) {
-      textStack.pop();
       textStack.peek().append("\n");
     }
     else if ("ul".equals(name)) {


### PR DESCRIPTION
Bug 1: Enter ```"hello"```, apply bullet effect, enter new line, enter ```"world"```, then converted xhtml is: ```"<ul><li>hell</li></ul><ul><li>worl</li></ul>"```. The last character of each list item is lost.

Bug 2: Convert ```"a<br/>b<br/>c"``` to spans and back, becomes ```"<br/>b<br/>c"```. This is due to ```Arrays.binarySearch(NO_ITEM_TAGS, name)<=0``` is true for br tags (```"br"``` is first item of ```NO_ITEM_TAGS```, ```binarySearch``` returns 0).

Bug 3: Spans can be unsorted, so we must sort it first. Enter a bullet list (hello, world), insert a new line between "he" and "llo", convert to xhtml, you will see ```"he\nllo\n<ul><li>world</li><li>he</li><li>llo</li></ul>world"```. Also in this bug we see that the ```\n``` before first span are not converted to ```<br/>```

Bug 4: New lines are added when the text is ending with odd number of empty lines: ```</div><div><br/>``` becomes ```</div><div><br/></div>``` becomes ```\n\n\n\n\n``` becomes ```</div><div></div><div><br/>``` becomes ```</div><div></div><div><br/></div>```.

Bug 5: The next line is bulletized when I apply bullet effect at end of line. This is because ```extendToFullLine``` skips current character.

I added some code to demo for testing xhtml, bullet, link. So you can pick commit 296958b first to check these bugs.